### PR TITLE
Enable to set from address

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -560,12 +560,15 @@ class Event extends Component
      */
     protected function emailOutput(MailerInterface $mailer, $addresses)
     {
-        $mailer->compose()
-            ->setTextBody(file_get_contents($this->_output))
-            ->setSubject($this->getEmailSubject())
-            ->setFrom($this->_fromAddress)
-            ->setTo($addresses)
-            ->send();
+        $textBody = file_get_contents($this->_output);
+        if ($textBody > '' ) {
+            $mailer->compose()
+                ->setTextBody($textBody)
+                ->setSubject($this->getEmailSubject())
+                ->setFrom($this->_fromAddress)
+                ->setTo($addresses)
+                ->send();
+        }
     }
 
     /**

--- a/Event.php
+++ b/Event.php
@@ -72,6 +72,12 @@ class Event extends Component
      * @var string
      */
     protected $_description;
+    /**
+     * The From address used by mailer.
+     *
+     * @var string
+     */
+    protected $_fromAddress;
 
     /**
      * Create a new event instance.
@@ -557,6 +563,7 @@ class Event extends Component
         $mailer->compose()
             ->setTextBody(file_get_contents($this->_output))
             ->setSubject($this->getEmailSubject())
+            ->setFrom($this->_fromAddress)
             ->setTo($addresses)
             ->send();
     }
@@ -596,6 +603,18 @@ class Event extends Component
     public function description($description)
     {
         $this->_description = $description;
+        return $this;
+    }
+
+    /**
+     * Set the from address to be used by emailOutput.
+     *
+     * @param  string $address
+     * @return $this
+     */
+    public function fromAddress($address)
+    {
+        $this->_fromAddress = $address;
         return $this;
     }
 


### PR DESCRIPTION
Possibility to set Email From address. This is needed when Swift_SmtpTransport is used as mail provider.
From address can be set using:
`$schedule->command('foo')->fromAddress('example@example.com')->sendOutputTo($filePath)->emailOutputTo('foo@example.com');`