### PR TITLE
Allow 3.* versions of `symfony/process`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.4.0",
     "yiisoft/yii2": "2.0.*",
-    "symfony/process": "2.6.*",
+    "symfony/process": "2.6.* || 3.*",
     "mtdowling/cron-expression": "~1.0"
   },
   "suggest": {


### PR DESCRIPTION
Due to [CHANGELOG](https://github.com/symfony/process/blob/master/CHANGELOG.md) version 3.* deprecations doesn't affect `\omnilight\scheduling\Event::runCommandInForeground`, so version 3.* can safely be added to composer constraint.