### PR TITLE
Prevent sending of empty mails

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -591,7 +591,7 @@ class Event extends Component
 
         if (trim($textBody) != '' ) {
             $mailer->compose()
-                ->setTextBody(file_get_contents($this->_output))
+                ->setTextBody($textBody)
                 ->setSubject($this->getEmailSubject())
                 ->setTo($addresses)
                 ->send();

--- a/Event.php
+++ b/Event.php
@@ -587,11 +587,15 @@ class Event extends Component
      */
     protected function emailOutput(MailerInterface $mailer, $addresses)
     {
-        $mailer->compose()
-            ->setTextBody(file_get_contents($this->_output))
-            ->setSubject($this->getEmailSubject())
-            ->setTo($addresses)
-            ->send();
+        $textBody = file_get_contents($this->_output);
+
+        if (trim($textBody) != '' ) {
+            $mailer->compose()
+                ->setTextBody(file_get_contents($this->_output))
+                ->setSubject($this->getEmailSubject())
+                ->setTo($addresses)
+                ->send();
+        }
     }
 
     /**


### PR DESCRIPTION
When a task produces no output, no mail should be sent.