### PR TITLE
Enhance onOneServer & withoutOverlapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Below shows the redis mutex demo:
 'components' => [
     'mutex' => [
         'class' => 'yii\redis\Mutex',
+        'autoRelease' => false, // You should disable autoRelease here
         'redis' => [
             'hostname' => 'localhost',
             'port' => 6379,

--- a/src/CallbackEvent.php
+++ b/src/CallbackEvent.php
@@ -73,7 +73,7 @@ class CallbackEvent extends Event
      * @return $this
      * @throws InvalidParamException
      */
-    public function withoutOverlapping($expiresAt = 86400)
+    public function withoutOverlapping($expiresAt = 1440)
     {
         if (empty($this->_description)) {
             throw new InvalidParamException(

--- a/src/CallbackEvent.php
+++ b/src/CallbackEvent.php
@@ -69,10 +69,11 @@ class CallbackEvent extends Event
     /**
      * Do not allow the event to overlap each other.
      *
+     * @param  int  $expiresAt
      * @return $this
      * @throws InvalidParamException
      */
-    public function withoutOverlapping()
+    public function withoutOverlapping($expiresAt = 86400)
     {
         if (empty($this->_description)) {
             throw new InvalidParamException(
@@ -80,7 +81,7 @@ class CallbackEvent extends Event
             );
         }
 
-        return parent::withoutOverlapping();
+        return parent::withoutOverlapping($expiresAt);
     }
 
     /**

--- a/src/Event.php
+++ b/src/Event.php
@@ -514,9 +514,9 @@ class Event extends Component
     public function withoutOverlapping($expiresAt = 86400)
     {
         return $this->then(function() {
-            $this->_mutex->release($this->mutexName(), $expiresAt);
-        })->skip(function() {
-            return !$this->_mutex->acquire($this->mutexName());
+            $this->_mutex->release($this->mutexName());
+        })->skip(function() use ($expiresAt) {
+            return !$this->_mutex->acquire($this->mutexName(), $expiresAt);
         });
     }
 
@@ -533,9 +533,9 @@ class Event extends Component
         $time = new \DateTime('now');
         $name = $this->mutexName() . $time->format('Hi');
         return $this->then(function() use ($name) {
-            $this->_mutex->release($name, 3600);
+            $this->_mutex->release($name);
         })->skip(function() use ($name) {
-            return !$this->_mutex->acquire($name);
+            return !$this->_mutex->acquire($name, 3600);
         });
     }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -511,12 +511,12 @@ class Event extends Component
      * @param  int  $expiresAt
      * @return $this
      */
-    public function withoutOverlapping($expiresAt = 86400)
+    public function withoutOverlapping($expiresAt = 1440)
     {
         return $this->then(function() {
             $this->_mutex->release($this->mutexName());
         })->skip(function() use ($expiresAt) {
-            return !$this->_mutex->acquire($this->mutexName(), $expiresAt);
+            return !$this->_mutex->acquire($this->mutexName(), $expiresAt * 60);
         });
     }
 
@@ -532,9 +532,7 @@ class Event extends Component
         }
         $time = new \DateTime('now');
         $name = $this->mutexName() . $time->format('Hi');
-        return $this->then(function() use ($name) {
-            $this->_mutex->release($name);
-        })->skip(function() use ($name) {
+        return $this->skip(function() use ($name) {
             return !$this->_mutex->acquire($name, 3600);
         });
     }


### PR DESCRIPTION
1. withoutOverlapping can specify minutes to expire when using redis mutex

> If needed, you may specify how many minutes must pass before the "without overlapping" lock expires. By default, the lock will expire after 24 hours:

2. onOneServer generated a mutex related to the time, and should not release immediately. If the schedule run very quickly, then the mutex will be auto relese. Schedules on other servers may can also run at the same time.

People who want this feature should config the redis mutex and disable autoRelease.

```
    'mutex' => [
        'class' => 'yii\redis\Mutex',
        'autoRelease' => false, // You should disable autoRelease here
        'redis' => [
            'hostname' => 'localhost',
            'port' => 6379,

```