### PR TITLE
add option to enable/avoid error output

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -88,6 +88,13 @@ class Event extends Component
     protected $_mutex;
 
     /**
+     * Decide if errors will be displayed.
+     *
+     * @var bool
+     */
+    protected $_omitErrors = false;
+
+    /**
      * Create a new event instance.
      *
      * @param Mutex $mutex
@@ -147,7 +154,7 @@ class Event extends Component
      */
     public function buildCommand()
     {
-        $command = $this->command . $this->_redirect . $this->_output . ' 2>&1 &';
+        $command = $this->command . $this->_redirect . $this->_output . ' ' . (($this->_omitErrors) ? '' : ' 2>&1 &');
         return $this->_user ? 'sudo -u ' . $this->_user . ' ' . $command : $command;
     }
 
@@ -502,6 +509,18 @@ class Event extends Component
     public function user($user)
     {
         $this->_user = $user;
+        return $this;
+    }
+
+    /**
+     * Set if errors should be displayed
+     *
+     * @param  bool $omitErrors
+     * @return $this
+     */
+    public function omitErrors(bool $omitErrors = false)
+    {
+        $this->_omitErrors = $omitErrors;
         return $this;
     }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -154,7 +154,7 @@ class Event extends Component
      */
     public function buildCommand()
     {
-        $command = $this->command . $this->_redirect . $this->_output . ' ' . (($this->_omitErrors) ? '' : ' 2>&1 &');
+        $command = $this->command . $this->_redirect . $this->_output . ' ' . (($this->_omitErrors) ? ' 2>&1 &' : '');
         return $this->_user ? 'sudo -u ' . $this->_user . ' ' . $command : $command;
     }
 

--- a/src/ScheduleController.php
+++ b/src/ScheduleController.php
@@ -19,10 +19,15 @@ class ScheduleController extends Controller
      */
     public $scheduleFile;
 
+    /**
+     * @var bool set to true to avoid error output
+     */
+    public $omitErrors = false;
+
     public function options($actionID)
     {
         return array_merge(parent::options($actionID),
-            $actionID == 'run' ? ['scheduleFile'] : []
+            $actionID == 'run' ? ['scheduleFile', 'omitErrors'] : []
         );
     }
 
@@ -45,6 +50,7 @@ class ScheduleController extends Controller
         $events = $this->schedule->dueEvents(\Yii::$app);
 
         foreach ($events as $event) {
+            $event->omitErrors($this->omitErrors);
             $this->stdout('Running scheduled command: '.$event->getSummaryForDisplay()."\n");
             $event->run(\Yii::$app);
         }


### PR DESCRIPTION
We have found that there is no way to see errors caused by this module. This is important if, for example, you have typos in your schedule configuration file. This PR adds the option to disable the error output (stderr) and enables it by default.