### PR TITLE
delete hint bool in method (for php 5)

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -518,7 +518,7 @@ class Event extends Component
      * @param  bool $omitErrors
      * @return $this
      */
-    public function omitErrors(bool $omitErrors = false)
+    public function omitErrors($omitErrors = false)
     {
         $this->_omitErrors = $omitErrors;
         return $this;


### PR DESCRIPTION
Hint bool available only in php 7