### PR TITLE
Don't allow string in _timezone property

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -35,7 +35,7 @@ class Event extends Component
     /**
      * The timezone the date should be evaluated on.
      *
-     * @var \DateTimeZone|string
+     * @var \DateTimeZone
      */
     protected $_timezone;
     /**
@@ -199,10 +199,7 @@ class Event extends Component
      */
     protected function expressionPasses()
     {
-        $date = new \DateTime('now');
-        if ($this->_timezone) {
-            $date->setTimezone($this->_timezone);
-        }
+        $date = new \DateTime('now', $this->_timezone);
         return CronExpression::factory($this->_expression)->isDue($date);
     }
 
@@ -491,10 +488,10 @@ class Event extends Component
     /**
      * Set the timezone the date should be evaluated on.
      *
-     * @param  \DateTimeZone|string $timezone
+     * @param  \DateTimeZone $timezone
      * @return $this
      */
-    public function timezone($timezone)
+    public function timezone(\DateTimeZone $timezone)
     {
         $this->_timezone = $timezone;
         return $this;


### PR DESCRIPTION
Having string in `_timezone` property didn't have any effect:

```
php > $date = new \DateTime();
php > var_dump($date->getTimezone()->getName());
string(3) "UTC"
php > $date->setTimezone('Europe/Berlin');

Warning: DateTime::setTimezone() expects parameter 1 to be DateTimeZone, string given in php shell code on line 1
php > var_dump($date->getTimezone()->getName());
string(3) "UTC"
```