### PR TITLE
Fixes for pipeline

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -143,7 +143,7 @@ class Event extends Component
     {
         $command = trim($this->buildCommand(), '& ');
         $cwd = dirname($app->request->getScriptFile());
-        if (method_exists(Process::class, 'fromShellCommandline')) {
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
             $process = Process::fromShellCommandline($command, $cwd, null, null, null);
         }
         else {

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -10,8 +10,8 @@ class EventTest extends \PHPUnit_Framework_TestCase
     public function buildCommandData()
     {
         return [
-            [false, 'php -i', '/dev/null', 'php -i > /dev/null'],
-            [false, 'php -i', '/my folder/foo.log', 'php -i > /my folder/foo.log'],
+            [false, 'php -i', '/dev/null', 'php -i > /dev/null &'],
+            [false, 'php -i', '/my folder/foo.log', 'php -i > /my folder/foo.log &'],
             [true, 'php -i', '/dev/null', 'php -i > /dev/null 2>&1 &'],
             [true, 'php -i', '/my folder/foo.log', 'php -i > /my folder/foo.log 2>&1 &'],
         ];


### PR DESCRIPTION
In #73 and #76 errors in testing are introduced. 

- `Event.php` using `::class` is supported since PHP 5.5, tests use 5.4
- `EventTest.php` in #76 an `&` is added to each command, tests now also do this